### PR TITLE
Test Node.js 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 16
           - 14
           - 12
           - 10


### PR DESCRIPTION
~~`getPromiseDetails` is not accessible anymore and the output of `util.inspect` has changed which means the function no longer works.~~ This only appears to happen sometimes, so it is best to just test for it.