### PR TITLE
Fix Node.js 16 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,5 @@
 'use strict';
-
-const states = [
-	'pending',
-	'fulfilled',
-	'rejected'
-];
+const {inspect} = require('util');
 
 module.exports.promiseStateAsync = require('./browser').promiseStateAsync;
 
@@ -14,22 +9,20 @@ module.exports.promiseStateSync = promise => {
 		throw new TypeError(`Expected a promise, got ${typeof promise}`);
 	}
 
-	try {
-		// eslint-disable-next-line node/no-deprecated-api
-		const [stateIndex] = process.binding('util').getPromiseDetails(promise);
-		return states[stateIndex];
-	} catch {
-		const {inspect} = require('util');
-		const inspectedString = inspect(promise);
+	const inspectedString = inspect(promise, {
+		depth: 0,
+		showProxy: false,
+		maxStringLength: 0,
+		breakLength: Infinity
+	});
 
-		if (inspectedString.startsWith('Promise { <pending> ')) {
-			return 'pending';
-		}
-
-		if (inspectedString.startsWith('Promise { <rejected> ')) {
-			return 'rejected';
-		}
-
-		return 'fulfilled';
+	if (inspectedString.startsWith('Promise { <pending>')) {
+		return 'pending';
 	}
+
+	if (inspectedString.startsWith('Promise { <rejected>')) {
+		return 'rejected';
+	}
+
+	return 'fulfilled';
 };


### PR DESCRIPTION
Since Node.js 16, the `getPromiseDetails` function sometimes doesn't exist:

<img alt="A screenshot of the Node.js 16.9.0 REPL where it is demonstrated that the `getPromiseDetails` function does not exist on the object that is returned by process.binding('util');" src="https://user-images.githubusercontent.com/29491356/132690551-4d64a446-199c-4d17-895a-69a9f8d23dbf.png" width="300px" />

As such, I've removed its use in `promiseStateSync` in favour of solely using `util.inspect()`. I added the `breakLength` option because on my installation, Node.js was detecting internal properties which was causing automatic line breaks that broke the string checks:

<img alt="A screenshot of the Node.js 16.9.0 REPL where it is demonstrated that `require('util').inspect(Promise.resolve());` yields a string containg newlines because of automatic line breaking which was caused by internal properties being detected" src="https://user-images.githubusercontent.com/29491356/132691881-57b9ea57-e701-4dbb-881d-4573080f4873.png" width="300px" />

I added the other options to ensure the function would not actually try to process anything if the promise had resolved since we don't care about those values.